### PR TITLE
feat: migrate to api v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This action publishes your Chrome extension to
 [Chrome Web Store](https://chrome.google.com/webstore/) using the
-[Chrome Web Store API v1.1](https://developer.chrome.com/docs/webstore/api_index/#items).
+[Chrome Web Store API v2](https://developer.chrome.com/docs/webstore/api).
 
 This action can only publish new version of an existing extension. Publishing new extension is not
 supported.
@@ -15,21 +15,25 @@ supported.
 Following items are required before publishing your Chrome extension:
 
 - A zip file to be uploaded.
+- Your Chrome Web Store publisher ID.
 - An API client ID and secret.
 - A refresh token.
 
-Please refer to this [tutorial](https://developer.chrome.com/docs/webstore/using_webstore_api/) for
-how to generate API keys and refresh token.
+Please refer to this [tutorial](https://developer.chrome.com/docs/webstore/using-api) for how to
+generate API keys, refresh token, and locate your publisher ID.
 
 ## Usage
 
 Unless otherwise noted with a default value, all options are required.
 
+- `publisher-id`: your Chrome Web Store publisher ID, available in the Developer Dashboard account
+  section.
 - `extension-id`: the id of your extension; can be referred from the url of your extension page on
   the Web Store.
 - `zip-path`: path to the zip file built in the previous steps. May include a glob pattern (only one
   file must match)
-- `tester-only`: (boolean) `true` indicates publishing to testers only; default to `false`.
+- `tester-only`: (boolean) deprecated in v2. The API now publishes using the existing visibility
+  settings configured in the Developer Dashboard; default to `false`.
 - `upload-only`: (boolean) `true` indicates this extension will be uploaded without publishing
   (you'll have to publish it manually); default to `false`.
 - `client-id`: your API client ID.
@@ -37,7 +41,8 @@ Unless otherwise noted with a default value, all options are required.
 - `refresh-token`: your refresh token.
 - `check-credentials-only`: (boolean) only test if given credentials are working; do not upload
   or publish the extension; enabling this option will ignore `extension-id`, `zip-path`,
-  `tester-only` and `upload-only` and make these options optional; default to `false`.
+  `tester-only`, `upload-only`, and `publisher-id` and make these options optional; default to
+  `false`.
 
 Example of uploading and publishing an extension:
 
@@ -45,6 +50,7 @@ Example of uploading and publishing an extension:
 steps:
   - uses: wdzeng/chrome-extension@v1
     with:
+      publisher-id: your-publisher-id
       extension-id: your-extension-id
       zip-path: your-extension.zip
       client-id: ${{ secrets.CHROME_CLIENT_ID }}
@@ -67,8 +73,8 @@ steps:
 ## References
 
 - [Obtaining OAuth 2.0 access tokens](https://developers.google.com/identity/protocols/oauth2/web-server#httprest_1)
-- [Using the Chrome Web Store Publish API](https://developer.chrome.com/docs/webstore/using_webstore_api/)
-- [Chrome Web Store API](https://developer.chrome.com/docs/webstore/api_index/)
+- [Use the Chrome Web Store API](https://developer.chrome.com/docs/webstore/using-api)
+- [Chrome Web Store API](https://developer.chrome.com/docs/webstore/api)
 
 ## Sister Actions
 

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,9 @@ description: GitHub action for publishing extensions to Chrome Web Store
 author: hyperbola
 
 inputs:
+  publisher-id:
+    description: Chrome Web Store publisher ID.
+    required: false
   extension-id:
     description: Extension ID.
     required: false
@@ -10,7 +13,7 @@ inputs:
     description: Path to zip file of the extension.
     required: false
   tester-only:
-    description: Whether the extension is published to trusted testers only. Default to false.
+    description: Deprecated. Chrome Web Store API v2 publishes using the item's existing visibility settings from the Developer Dashboard. Default to false.
     required: false
     default: "false"
   upload-only:

--- a/src/chrome-store-utils.ts
+++ b/src/chrome-store-utils.ts
@@ -5,17 +5,17 @@ import * as core from '@actions/core'
 import axios from 'axios'
 
 import type {
+  FetchStatusResponseData,
   ItemPublishResponseData,
-  ItemResponseData,
   OAuth2TokenResponse,
-  UnsuccessfulItemResponseData,
+  UploadItemResponseData,
   UploadState
 } from '@/types'
 
 import type { AxiosResponse, RawAxiosRequestHeaders } from 'axios'
 import { globSync } from 'glob'
 
-// https://developer.chrome.com/docs/webstore/using_webstore_api/
+// https://developer.chrome.com/docs/webstore/using-api
 
 export async function generateJwtToken(
   clientId: string,
@@ -25,13 +25,14 @@ export async function generateJwtToken(
   // https://developers.google.com/identity/protocols/oauth2/web-server#httprest_1
   core.info('Start to refresh access token.')
   const response = await axios.post<OAuth2TokenResponse>(
-    'https://www.googleapis.com/oauth2/v4/token',
-    {
+    'https://oauth2.googleapis.com/token',
+    new URLSearchParams({
       client_id: clientId,
       client_secret: clientSecret,
       grant_type: 'refresh_token',
       refresh_token: refreshToken
-    }
+    }),
+    { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
   )
 
   const accessToken = response.data.access_token
@@ -42,95 +43,102 @@ export async function generateJwtToken(
 }
 
 export async function updatePackage(
+  publisherId: string,
   extId: string,
   zipPath: string,
   token: string
 ): Promise<boolean> {
-  let url: string
-  let headers: RawAxiosRequestHeaders
-  let response: AxiosResponse<ItemResponseData>
   let uploadState: UploadState
+  let fetchStatusResponse: AxiosResponse<FetchStatusResponseData> | undefined
 
-  // https://developer.chrome.com/docs/webstore/using_webstore_api/#uploadexisitng
-  // https://developer.chrome.com/docs/webstore/using_webstore_api/#checkstatus
+  // https://developer.chrome.com/docs/webstore/using-api#upload-a-package-to-update-an-existing-store-item
+  // https://developer.chrome.com/docs/webstore/api/reference/rest/v2/media/upload
+  // https://developer.chrome.com/docs/webstore/api/reference/rest/v2/publishers.items/fetchStatus
 
   core.info('Start to update extension package.')
 
-  url = `https://www.googleapis.com/upload/chromewebstore/v1.1/items/${extId}?uploadType=media`
+  const itemName = `publishers/${publisherId}/items/${extId}`
+  const url = `https://chromewebstore.googleapis.com/upload/v2/${itemName}:upload`
   const body = fs.createReadStream(path.resolve(zipPath))
-  headers = { 'Authorization': `Bearer ${token}`, 'x-goog-api-version': '2' }
-  response = await axios.put<ItemResponseData>(url, body, {
+  const headers: RawAxiosRequestHeaders = { 'Authorization': `Bearer ${token}` }
+  const uploadResponse = await axios.post<UploadItemResponseData>(url, body, {
     headers,
     maxContentLength: Number.POSITIVE_INFINITY
   })
-  uploadState = response.data.uploadState
+  uploadState = uploadResponse.data.uploadState
 
-  core.debug(`Response status code: ${response.status}`)
-  core.debug(JSON.stringify(response.data))
+  core.debug(`Response status code: ${uploadResponse.status}`)
+  core.debug(JSON.stringify(uploadResponse.data))
 
   // Wait until package uploaded.
-  headers = {
-    'Authorization': `Bearer ${token}`,
-    'Content-Length': '0',
-    'Expect': '',
-    'x-goog-api-version': '2'
-  }
-  url = `https://www.googleapis.com/chromewebstore/v1.1/items/${extId}?projection=DRAFT`
+  const statusUrl = `https://chromewebstore.googleapis.com/v2/${itemName}:fetchStatus`
   while (uploadState === 'IN_PROGRESS') {
     core.info('Package is still uploading. Wait for 10 seconds.')
     await new Promise(res => setTimeout(res, 10000))
 
-    response = await axios<ItemResponseData>(url, { headers })
-    uploadState = response.data.uploadState
+    fetchStatusResponse = await axios.get<FetchStatusResponseData>(statusUrl, { headers })
+    uploadState = fetchStatusResponse.data.lastAsyncUploadState ?? 'UPLOAD_STATE_UNSPECIFIED'
   }
 
-  if (uploadState === 'SUCCESS') {
+  if (uploadState === 'SUCCEEDED') {
     core.info('Extension package updated.')
     return true
   }
 
-  const errorResponse = response.data as UnsuccessfulItemResponseData
   core.error('Failed to update extension package.')
-  for (const errMsg of errorResponse.itemError) {
-    core.error(errMsg.error_detail)
+  if (fetchStatusResponse) {
+    const submittedState = fetchStatusResponse.data.submittedItemRevisionStatus?.state
+    if (submittedState) {
+      core.error(`Submitted revision state: ${submittedState}`)
+    }
+    if (fetchStatusResponse.data.takenDown) {
+      core.error('The item is currently taken down. Check the Developer Dashboard for details.')
+    }
+    if (fetchStatusResponse.data.warned) {
+      core.error('The item currently has an active warning in the Developer Dashboard.')
+    }
   }
+  core.error(`Upload state: ${uploadState}`)
   return false
 }
 
 export async function publishExtension(
+  publisherId: string,
   extId: string,
   testerOnly: boolean,
   token: string
 ): Promise<boolean> {
-  // https://developer.chrome.com/docs/webstore/using_webstore_api/#publishpublic
-  // https://developer.chrome.com/docs/webstore/using_webstore_api/#trustedtesters
+  // https://developer.chrome.com/docs/webstore/using-api#publish-an-item
+  // https://developer.chrome.com/docs/webstore/api/reference/rest/v2/publishers.items/publish
   core.info('Start to publish extension.')
+  if (testerOnly) {
+    core.warning(
+      "The Chrome Web Store API v2 no longer supports selecting trusted testers via request parameter. The item will publish using its existing visibility settings from the Developer Dashboard."
+    )
+  }
 
-  const url = `https://www.googleapis.com/chromewebstore/v1.1/items/${extId}/publish`
-  const publishTarget = testerOnly ? 'trustedTesters' : 'default'
+  const itemName = `publishers/${publisherId}/items/${extId}`
+  const url = `https://chromewebstore.googleapis.com/v2/${itemName}:publish`
   const headers = {
     'Authorization': `Bearer ${token}`,
-    'Content-Length': '0',
-    'x-goog-api-version': '2'
+    'Content-Length': '0'
   }
-  const response = await axios.post<ItemPublishResponseData>(url, undefined, {
-    headers,
-    params: { publishTarget }
-  })
+  const response = await axios.post<ItemPublishResponseData>(url, undefined, { headers })
 
   core.debug(`Response status code: ${response.status}`)
   core.debug(JSON.stringify(response.data))
 
-  const status = response.data.status
-  if (status.length === 1 && status[0] === 'OK') {
-    core.info('Extension published.')
+  if (
+    response.data.state === 'PENDING_REVIEW' ||
+    response.data.state === 'PUBLISHED' ||
+    response.data.state === 'PUBLISHED_TO_TESTERS' ||
+    response.data.state === 'STAGED'
+  ) {
+    core.info(`Extension publish request accepted. Current state: ${response.data.state}.`)
     return true
   }
 
-  core.error(`Failed to publish extension: ${status.join(', ')}`)
-  for (const msg of response.data.statusDetail) {
-    core.error(msg)
-  }
+  core.error(`Failed to publish extension. Current state: ${response.data.state}`)
   return false
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { generateJwtToken, publishExtension, tryResolvePath, updatePackage } fro
 import { handleError } from './errors'
 
 async function run(
+  publisherId: string,
   extensionId: string,
   zipPath: string,
   testerOnly: boolean,
@@ -17,20 +18,20 @@ async function run(
   let success: boolean
 
   const jwtToken = await generateJwtToken(clientId, clientSecret, refreshToken)
-  success = await updatePackage(extensionId, zipPath, jwtToken)
+  success = await updatePackage(publisherId, extensionId, zipPath, jwtToken)
   if (!success) {
     process.exit(1)
   }
 
   if (!uploadOnly) {
     // Do we need to publish the extension?
-    success = await publishExtension(extensionId, testerOnly, jwtToken)
+    success = await publishExtension(publisherId, extensionId, testerOnly, jwtToken)
     if (!success) {
       process.exit(1)
     }
   }
 
-  core.info('Extension published successfully.')
+  core.info(uploadOnly ? 'Extension upload completed successfully.' : 'Extension published successfully.')
 }
 
 async function main(): Promise<void> {
@@ -48,6 +49,7 @@ async function main(): Promise<void> {
     return
   }
 
+  const publisherId = core.getInput('publisher-id', { required: true })
   const extensionId = core.getInput('extension-id', { required: true })
   let zipPath = core.getInput('zip-path', { required: true })
   const testerOnly = core.getBooleanInput('tester-only')
@@ -55,7 +57,16 @@ async function main(): Promise<void> {
 
   try {
     zipPath = tryResolvePath(zipPath)
-    await run(extensionId, zipPath, testerOnly, uploadOnly, clientId, clientSecret, refreshToken)
+    await run(
+      publisherId,
+      extensionId,
+      zipPath,
+      testerOnly,
+      uploadOnly,
+      clientId,
+      clientSecret,
+      refreshToken
+    )
   } catch (e: unknown) {
     handleError(e)
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-// https://developer.chrome.com/docs/webstore/using_webstore_api/#test-oauth
+// https://developer.chrome.com/docs/webstore/using-api
 // https://developers.google.com/identity/protocols/oauth2/web-server#httprest_3
 export interface OAuth2TokenResponse {
   access_token: string
@@ -8,46 +8,53 @@ export interface OAuth2TokenResponse {
   token_type: 'Bearer'
 }
 
-// https://developer.chrome.com/docs/webstore/webstore_api/items/
-export type UploadState = 'FAILURE' | 'IN_PROGRESS' | 'NOT_FOUND' | 'SUCCESS'
+// https://developer.chrome.com/docs/webstore/api/reference/rest/v2/UploadState
+export type UploadState =
+  | 'FAILED'
+  | 'IN_PROGRESS'
+  | 'NOT_FOUND'
+  | 'SUCCEEDED'
+  | 'UPLOAD_STATE_UNSPECIFIED'
 
-export interface SuccessfulItemResponseData {
-  id: string
-  kind: 'chromewebstore#item'
-  publicKey: string
-  uploadState: 'SUCCESS'
+export interface UploadItemResponseData {
+  name: string
+  itemId: string
+  crxVersion?: string
+  uploadState: UploadState
 }
 
-// The Chrome Web store returns a 200 response even if the upload fails.
-export interface UnsuccessfulItemResponseData {
-  id: string
-  itemError: {
-    error_code: string // Includes `ITEM_NOT_UPDATABLE`; not sure what other values are possible.
-    error_detail: string // Human readable error message.
+// https://developer.chrome.com/docs/webstore/api/reference/rest/v2/ItemState
+export type ItemState =
+  | 'CANCELLED'
+  | 'ITEM_STATE_UNSPECIFIED'
+  | 'PENDING_REVIEW'
+  | 'PUBLISHED'
+  | 'PUBLISHED_TO_TESTERS'
+  | 'REJECTED'
+  | 'STAGED'
+
+export interface ItemRevisionStatus {
+  state: ItemState
+  distributionChannels?: {
+    crxVersion: string
+    deployPercentage: number
   }[]
-  kind: 'chromewebstore#item'
-  uploadState: 'FAILURE' | 'IN_PROGRESS' | 'NOT_FOUND'
 }
 
-// https://developer.chrome.com/docs/webstore/webstore_api/items/
-export type ItemResponseData = SuccessfulItemResponseData | UnsuccessfulItemResponseData
+export interface FetchStatusResponseData {
+  name: string
+  itemId: string
+  publicKey: string
+  lastAsyncUploadState?: UploadState
+  publishedItemRevisionStatus?: ItemRevisionStatus
+  submittedItemRevisionStatus?: ItemRevisionStatus
+  takenDown: boolean
+  warned: boolean
+}
 
-// https://developer.chrome.com/docs/webstore/webstore_api/items/publish/
-export type PublishStatus =
-  | 'OK'
-  | 'NOT_AUTHORIZED'
-  | 'INVALID_DEVELOPER'
-  | 'DEVELOPER_NO_OWNERSHIP'
-  | 'DEVELOPER_SUSPENDED'
-  | 'ITEM_NOT_FOUND'
-  | 'ITEM_PENDING_REVIEW'
-  | 'ITEM_TAKEN_DOWN'
-  | 'PUBLISHER_SUSPENDED'
-
-// https://developer.chrome.com/docs/webstore/webstore_api/items/publish/
+// https://developer.chrome.com/docs/webstore/api/reference/rest/v2/publishers.items/publish
 export interface ItemPublishResponseData {
-  kind: 'chromewebstore#item'
-  item_id: string
-  status: PublishStatus[]
-  statusDetail: string[]
+  name: string
+  itemId: string
+  state: ItemState
 }


### PR DESCRIPTION
This updates the action inputs and request flow to match the new publisher-scoped endpoints and current OAuth/token flow. Most of the API helper logic was effectively rewritten to handle the new v2 request/response model, upload status flow, and publish behavior.

This should be tested further since I don't have a published chrome extension where I can reproduce all possible scenarios.